### PR TITLE
Ajout d'infos sur l'adresse de contact evenements

### DIFF
--- a/custom/pages/participer.inc.html
+++ b/custom/pages/participer.inc.html
@@ -11,6 +11,9 @@
     <li>Des salons <a href="http://wiki.mozfr.org/IRC" title="IRC" class="mw-redirect">canal IRC francophone</a> vous permettent de discuter en ligne avec les membres de la communauté qui y sont connectés en même temps que vous depuis divers endroits dans le monde. Certains salons sont thématiques (développement, aide), mais vous pouvez aussi discuter de tout et de rien sur #frenchmoz.</li>
     <li>Nous sommes présents sur plusieurs réseaux sociaux dont <a href="https://twitter.com/#!/mozilla_fr">Twitter</a>, <a href="https://free-beer.ch/u/mozfr">Diaspora</a> et <a href="https://www.facebook.com/frmozilla">page Facebook</a>.</li>
   </ul>
+  <h2 id="Inviter_la_communaut.C3.A9">Inviter la communauté à votre évènement</h2>
+  <p>Vous organisez un évènement et vous souhaiteriez une présence de MozFr (un conférencier, un stand, des goodies, &hellip;)&#160;?</p>
+  <p>Contactez-nous via les liens ci-dessus, ou par courriel à l'adresse <i>evenements</i>(à)<i>mozfr.org</i>.</p>
   <h2 id="Organisation_de_MozFr">Organisation de MozFr</h2>
   <p>Nous avons choisi de répartir les contributions possibles entre cinq groupes de travail, suivant les domaines qu'elles concernent et les compétences qu'elles demandent, avec chacun un référent. Il est tout à fait possible de participer à plusieurs groupes simultanément.</p>
   <div id="traduction" class="accordion-panel">


### PR DESCRIPTION
Ajoute un paragraphe sur la page "participer" pour indiquer comment faire pour inviter la communauté à un évènement.
