### PR TITLE
Correct path to CSS when app is in a subfolder

### DIFF
--- a/custom/views/default/static-pages.tpl.php
+++ b/custom/views/default/static-pages.tpl.php
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width,initial-scale=1" />
   <title>Mozilla Francophone :: <?= $pageTitle ?></title>
-  <link rel="stylesheet" type="text/css" href="/custom/style/mozfr.css" />
+  <link rel="stylesheet" type="text/css" href="./custom/style/mozfr.css" />
   <link rel="shortcut icon" type="image/x-icon" href="./favicon.ico" />
   <style>
 /* Définitions */


### PR DESCRIPTION
When the website is not at the root of the server, CSS is not loaded on subpages.
