### PR TITLE
Mention the Firefox OS communication working group

### DIFF
--- a/custom/pages/participer.inc.html
+++ b/custom/pages/participer.inc.html
@@ -78,6 +78,22 @@
       <dd><a href="http://wiki.mozfr.org/Cat%C3%A9gorie:Communication" title="Catégorie:Communication">Page du groupe sur le Wiki</a></dd>
     </dl>
   </div>
+  <div id="communication_pour_firefox_os" class="accordion-panel">
+      <h3><a href="#communication_pour_firefox_os">Communication pour Firefox OS</a></h3>
+  <p>Mozilla a aidé la communauté à monter un groupe de communication pour faire connaître Firefox OS dans la francophonie et créer une conversation avec nos lecteurs et nos abonnés sur les réseaux sociaux. Nous publions des articles, nous postons des messages, des dessins, des vidéos… sur nos réseaux sociaux et organisons des événements autour de Firefox OS.</p>
+  <p>L'enthousiasme est la qualité indispensable. Pour le reste, venez comme vous êtes, nous vous aiderons à trouver votre place dans notre sympathique petite équipe.</p>
+  <dl>
+      <dt>Activités</dt>
+      <dd>Faire connaître Firefox OS et capturer l'intérêt du très grand public pour ce nouveau système d'exploitation mobile afin d'accélérer les conversations autour de Firefox OS.</dd>
+      <dt>Compétences recherchées</dt>
+      <dd>Enthousiasme et rédaction, graphisme, réseaux sociaux, organisation d'événements ou développement web.</dd>
+      <dt>Référents</dt>
+      <dd><a href="http://wiki.mozfr.org/Utilisateur:Kant1" title="Utilisateur:Kant1">Quentin</a> et <a href="http://wiki.mozfr.org/Utilisateur:Mozinet" title="Utilisateur:Mozinet">Mozinet</a></dd>
+      <dt>Sites de ce groupe</dt>
+      <dd><a href="http://firefoxos.mozfr.org/">Site</a></dd>
+      <dd><a href="http://wiki.mozfr.org/FirefoxOS/GroupeCommunication" title="FirefoxOS/GroupeCommunication">Page du groupe sur le Wiki</a></dd>
+  </dl>
+  </div>
   <div id="developpement" class="accordion-panel">
     <h3><a href="#developpement">Développement</a></h3>
     <p>Ici, on développe des outils pour MozFr, mais on s'entraide aussi pour maîtriser les technologies Web et la programmation dans divers langages, du JavaScript au C++&#160;!</p>


### PR DESCRIPTION
Sur requête de @Mozinet-fr sur la mailing list mozfr (pas testé, il fallait ?).

D'ailleurs, Mozinet, qu'est-ce que "accélerer les conversations autour de Firefox OS" veut dire ?