### PR TITLE
Composer unneeded

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,8 +15,9 @@ Thumbs.db
 /source/components/
 
 sculpin.phar
+composer.phar
 composer.lock
-vendor/
 
+vendor/
 output_dev/
 output_prod/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ Ceci est le code source de notre portail Mozilla Francophone <https://mozfr.org/
 
 Le site utilise le générateur statique Sculpin <https://sculpin.io/>.
 
-# Installer Sculpin et composer
+# Installer Sculpin
 
 ```
 curl -O https://download.sculpin.io/sculpin.phar

--- a/README.md
+++ b/README.md
@@ -2,9 +2,16 @@ Ceci est le code source de notre portail Mozilla Francophone <https://mozfr.org/
 
 Le site utilise le générateur statique Sculpin <https://sculpin.io/>.
 
-Pour compiler le site:
+# Installer Sculpin et composer
+
 ```
-sculpin generate --env=prod
+curl -O https://download.sculpin.io/sculpin.phar
+chmod +x sculpin.phar
+```
+
+# Compiler notre site
+```
+./sculpin.phar generate --env=prod
 ```
 
 Le dossier de sortie est output_prod.

--- a/composer.json
+++ b/composer.json
@@ -1,8 +1,0 @@
-{
-    "require": {
-        "sculpin/sculpin": "dev-master",
-        "dflydev/embedded-composer-console": "@dev",
-        "dflydev/embedded-composer-core": "@dev",
-        "composer/composer": "@dev"
-    }
-}

--- a/source/github_hook.php
+++ b/source/github_hook.php
@@ -5,6 +5,8 @@ date_default_timezone_set('Europe/Paris');
 
 // app variables
 $app_root = realpath(__DIR__ . '/../');
+$composer = $app_root . '/composer.phar';
+$sculpin = $app_root . '/sculpin.phar';
 
 // git variables
 $branch = 'master';
@@ -23,6 +25,22 @@ function logHookResult($message, $success = false)
     file_put_contents(__DIR__ . '/github_log.txt', $log_headers);
 }
 
+// CHECK: Download composer in the app root if it is not already there
+if (! file_exists($composer) and file_exists($app_root.'/composer.json')) {
+    file_put_contents(
+        $composer,
+        file_get_contents('https://getcomposer.org/composer.phar')
+    );
+}
+
+#Get Sculpin
+if (! file_exists($sculpin) and file_exists($app_root.'/sculpin.json')) {
+    file_put_contents(
+        $sculpin,
+        file_get_contents('https://download.sculpin.io/sculpin.phar')
+    );
+}
+
 if (isset($_SERVER[$header])) {
     $validation = hash_hmac(
         'sha1',
@@ -34,9 +52,30 @@ if (isset($_SERVER[$header])) {
         // Pull latest changes
         exec("git checkout $branch ; git pull origin $branch");
 
+        // Install or update dependencies
+        if (file_exists($composer) and file_exists($app_root.'/composer.json')) {
+            chdir($app_root);
+
+            // www-data does not have a HOME or COMPOSER_HOME, create one
+            if (! is_dir("{$app_root}/cache/.composer")) {
+                mkdir("{$app_root}/cache/.composer");
+            }
+
+            putenv("COMPOSER_HOME={$app_root}/cache/.composer");
+
+            if (file_exists($app_root . '/vendor')) {
+                exec("php {$composer} update > /dev/null 2>&1");
+            } else {
+                exec("php {$composer} install > /dev/null 2>&1");
+            }
+        }
+
         // Generate static site
-        chdir($app_root);
-        exec('php ./sculpin.phar generate --env=prod > /dev/null 2>&1');
+        if (file_exists($sculpin) and file_exists($app_root.'/sculpin.json')) {
+            chdir($app_root);
+
+            exec("php {$sculpin} generate --env=prod > /dev/null 2>&1");
+        }
 
         logHookResult('Last update: ' . date('d-m-Y H:i:s'), true);
     } else {

--- a/source/github_hook.php
+++ b/source/github_hook.php
@@ -33,7 +33,7 @@ if (! file_exists($composer) and file_exists($app_root.'/composer.json')) {
     );
 }
 
-#Get Sculpin
+// Get Sculpin
 if (! file_exists($sculpin) and file_exists($app_root.'/sculpin.json')) {
     file_put_contents(
         $sculpin,


### PR DESCRIPTION
I removed composer dependencies as we don't use any.
I also changed the way the github hook works.
It will get composer & do composer install/update only if there are ones so if tomorrow we really need such, we won't have to change our hook.
The script also now gets sculpin.phar from the official website (stable version), it should just work as before but in a cleaner way.
