### PR TITLE
Add a page for the Mozilla Paris office and FAQ at /mozillaparis

### DIFF
--- a/source/mozillaparis.html
+++ b/source/mozillaparis.html
@@ -1,0 +1,52 @@
+---
+layout: default
+title: Mozilla Paris Twitter
+---
+<section id="contrib">
+
+<h2>Mozilla Paris</h2>
+<p>
+    Le compte twitter <a href="https://twitter.com/MozillaParis">@MozillaParis</a> est tenu par des
+    employés du bureau désirant aider à diffuser la promotion des évènements se déroulant à Mozilla
+    Paris.<br/>
+    Cette page contient une liste de questions récurrentes et leurs réponses.
+</p>
+
+<h3 id="support">Comment obtenir du support technique ?</h3>
+<p>
+    Pour du support sur tous les programmes maintenus par Mozilla, vous pouvez poster sur le
+    <a href="https://forums.mozfr.org/">forum de la communauté francophone</a>, contacter par email
+    <a href="mailto:support@mozilla.com">support@mozilla.com</a> ou visiter
+    <a href="https://support.mozilla.org/fr/">notre site</a>.
+</p>
+
+<h3 id="sponsor">Comment envoyer une demande de sponsor ?</h3>
+<p>
+    Vous organisez un évènement lié à Mozilla ou à ses technologies et principes, et vous
+    souhaiteriez que Mozilla le sponsorise ? Visitez
+    <a href="https://wiki.mozilla.org/Events#sponsorships">ce site</a> pour plus d'informations.
+</p>
+
+<h3 id="evenement">Comment héberger un évènement à Mozilla Paris ?</h3>
+<p>
+    Vous organisez un évènement lié à Mozilla, au libre ou aux principes défendus par Mozilla ? Cet
+    évènement est gratuit et ouvert à tous ? Si vous recherchez un endroit pour héberger votre
+    évènement et accueillir les visiteurs, Mozilla peut peut-être vous accueillir au sein de ses
+    locaux parisiens !
+</p>
+
+<p>
+    Pour que votre évènement soit accueilli au sein des bureaux de Paris, veuillez envoyer un
+    descriptif le plus complet possible de celui-ci à la mailing list suivante :
+    <a href="mailto:paris-events@mozilla.org">paris-events@mozilla.org</a>. Ce descriptif devrait
+    contenir au moins les informations suivantes : </br>
+    <ul>
+        <li>Description de l'évènement</li>
+        <li>Description succincte de l'entité organisatrice</li>
+        <li>Nombre de personnes attendues</li>
+        <li>Dates ou périodes souhaitées</li>
+    </ul>
+    Si nous ne vous donnons pas de réponses en trois semaines, n'hésitez pas à nous recontacter.
+</p>
+
+</section>


### PR DESCRIPTION
Comme discuté par email avec Pascal, d'accord sur le principe. L'idée est d'avoir une page statique avec toutes les questions fréquemment posées au compte twitter MozillaParis, sur lequel nous ne désirons qu'annoncer les événements.