### PR TITLE
Retrait des communautés inactives

### DIFF
--- a/source/_layouts/default.html.twig
+++ b/source/_layouts/default.html.twig
@@ -97,20 +97,8 @@
             <div class="section">
                 <h2>Communautés</h2>
                 <ul id="communities">
-                    <li id="community-dz">
-                        <a href="http://mozilla-algeria.org/" title="site de la communauté algérienne">Mozilla Algeria</a>
-                    </li>
                     <li id="community-be">
                         <a href="http://mozilla-belgium.org/fr/" title="site de la communauté belge">Mozilla Belgium</a>
-                    </li>
-                    <li id="community-ma">
-                        <a href="http://mozilla.ma/" title="site de la communauté marocaine">Mozilla Morocco</a>
-                    </li>
-                    <li id="community-qc-ca">
-                        <a href="http://mozillaquebec.org/web/fr/" title="site de la communauté québecoise">Mozilla Québec</a>
-                    </li>
-                    <li id="community-sn">
-                        <a href="http://mozilla-senegal.org/" title="site de la communauté sénégalaise">Mozilla Senegal</a>
                     </li>
                     <li id="community-tn">
                         <a href="http://mozilla-tunisia.org/" title="site de la communauté tunisienne">Mozilla Tunisia</a>


### PR DESCRIPTION
Suite à https://github.com/mozfr/besogne/issues/14, retrait des communautés mentionnées comme inactives pour Mozilla francophone