### PR TITLE
Comparaison des HMAC en temps constant

### DIFF
--- a/source/github_hook.php
+++ b/source/github_hook.php
@@ -48,7 +48,7 @@ if (isset($_SERVER[$header])) {
         $secret
     );
 
-    if ($validation == explode('=', $_SERVER[$header])[1]) {
+    if (hash_equals($validation, explode('=', $_SERVER[$header])[1])) {
         // Pull latest changes
         exec("git checkout $branch ; git pull origin $branch");
 


### PR DESCRIPTION
Aloha,

Je propose de remplacer l'utilisation de `==` pour la comparaison des deux HMAC (utilisés pour s'assurer de l'origine et intégrité de la requête) par un appel à [hash_equals()](http://php.net/manual/en/function.hash-equals.php). 

La comparaison va être faite en temps constant. Il sera quand même possible de deviner la taille des deux chaînes comparées (la fonction retourne `FALSE` si elles ne font pas la même taille), mais tout le monde est déjà au courant que Github utilise SHA1 pour le hmac (que ça fera donc toujours 40 caractères). Également intéressant, cela permet d'éviter des attaques basées sur l'opérateur de comparaison *un peu trop permissif* `==`.

Je pense qu'il faudrait aussi bloquer l'accès à `/github_log.txt`.

Références :
- [Github conseille de ne pas utiliser l'opérateur `==`, justement dans ce gnere de cas.](https://developer.github.com/webhooks/securing/)
- [("0af..." == 0) !](http://stackoverflow.com/questions/14711474/strcmp-vs-vs-in-php-for-checking-hash-equality)
- [Magic hashes.](https://www.whitehatsec.com/blog/magic-hashes/)