### PR TITLE
Mise à jour des liens et du référent comm -Firefox OS

### DIFF
--- a/source/participer.html
+++ b/source/participer.html
@@ -12,11 +12,11 @@ title: Participer
     <h2 id="Discuter_avec_la_communaut.C3.A9">Discuter avec la communauté</h2>
     <ul>
         <li>Vous pouvez commencer par vous inscrire à la <a href="/liste">liste de diffusion</a> de la communauté francophone pour participer aux projets et partager des idées.</li>
-        <li>Des <a href="https://wiki.mozfr.org/IRC" title="IRC" class="mw-redirect">canaux IRC francophones</a> vous permettent de discuter en ligne avec les membres de la communauté qui y sont connectés en même temps que vous depuis divers endroits dans le monde. Certains salons sont thématiques (développement, aide…), mais vous pouvez aussi discuter de tout et de rien sur #frenchmoz.</li>
-        <li>Nous sommes présents sur <a href="https://twitter.com/mozilla_fr">Twitter</a>.</li>
+        <li>Des <a href="https://github.com/mozfr/besogne/wiki/IRC" title="IRC">canaux IRC francophones</a> vous permettent de discuter en ligne avec les membres de la communauté qui y sont connectés en même temps que vous depuis divers endroits dans le monde. Certains salons sont thématiques (développement, aide…), mais vous pouvez aussi discuter de tout et de rien sur #frenchmoz.</li>
+        <li>Nous sommes présents sur <a href="https://twitter.com/mozilla_fr">Twitter</a> et sur <a href="https://www.facebook.com/frmozilla/">Facebook</a>.</li>
     </ul>
     <h2 id="Inviter_la_communaut.C3.A9">Inviter la communauté à votre évènement</h2>
-    <p>Vous organisez un évènement et vous souhaiteriez une présence de MozFr (un conférencier, un stand, des goodies&hellip;)&#160;?</p>
+    <p>Vous organisez un évènement et vous souhaiteriez une présence de MozFr (un conférencier, un stand, des <i lang="en">goodies</i>&hellip;)&#160;?</p>
     <p>Contactez-nous via les liens ci-dessus ou par courriel à l'adresse <i>evenements</i>(à)<i>mozfr.org</i>.</p>
     <h2 id="Organisation_de_MozFr">Organisation de MozFr</h2>
     <p>Nous avons choisi de répartir les contributions possibles entre six groupes de travail, suivant les domaines qu'elles concernent et les compétences qu'elles demandent, avec chacun un référent. Il est tout à fait possible de participer à plusieurs groupes simultanément.</p>
@@ -75,27 +75,11 @@ title: Participer
             <dd>Faire connaître Mozilla et rassembler des gens autour de nos valeurs.</dd>
             <dt>Compétences souhaitées</dt>
             <dd>Rédaction, enthousiasme, organisation.</dd>
-            <dt>Référente</dt>
-            <dd><a href="https://wiki.mozfr.org/Utilisateur:Clarista" title="Utilisateur:Clarista">Clarista</a></dd>
-            <dt>Sites de ce groupe</dt>
-            <dd><a href="https://blog.mozfr.org/">Blog</a></dd>
-            <dd><a href="https://wiki.mozfr.org/Cat%C3%A9gorie:Communication" title="Catégorie:Communication">Page du groupe sur le Wiki</a></dd>
-        </dl>
-    </div>
-    <div id="communication_pour_firefox_os" class="accordion-panel">
-        <h3><a href="#communication_pour_firefox_os">Communication pour Firefox OS</a></h3>
-        <p>Mozilla a aidé la communauté à monter un groupe de communication pour faire connaître Firefox OS dans la francophonie et créer une conversation avec nos lecteurs et nos abonnés sur les réseaux sociaux. Nous publions des articles, nous postons des messages, des dessins, des vidéos… sur nos réseaux sociaux et organisons des événements autour de Firefox OS.</p>
-        <p>L'enthousiasme est la qualité indispensable. Pour le reste, venez comme vous êtes, nous vous aiderons à trouver votre place dans notre sympathique petite équipe.</p>
-        <dl>
-            <dt>Activités</dt>
-            <dd>Faire connaître Firefox OS et accélérer les conversations autour de Firefox OS et de <abbr title="Boot to Gecko">B2G</abbr>, le nom de code de Firefox OS qui se recentre sur les objets connectés, mais continue pour les smartphones aux mains de la communauté.</dd>
-            <dt>Compétences recherchées</dt>
-            <dd>Enthousiasme et rédaction, relecture, graphisme, réseaux sociaux, organisation d'événements ou développement web.</dd>
-            <dt>Référents</dt>
+            <dt>Référent</dt>
             <dd><a href="https://wiki.mozfr.org/Utilisateur:Mozinet" title="Utilisateur:Mozinet">Mozinet</a></dd>
             <dt>Sites de ce groupe</dt>
-            <dd><a href="https://firefoxos.mozfr.org/">Blog</a></dd>
-            <dd><a href="https://wiki.mozfr.org/FirefoxOS/GroupeCommunication" title="FirefoxOS/GroupeCommunication">Page du groupe sur le Wiki</a></dd>
+            <dd><a href="https://blog.mozfr.org/">Blog</a></dd>
+            <dd><a href="https://github.com/mozfr/besogne/wiki/Communication" title="Communication – wiki Mozfr">Page du groupe sur le Wiki</a></dd>
         </dl>
     </div>
     <div id="developpement" class="accordion-panel">
@@ -104,7 +88,7 @@ title: Participer
         <p>Si vous avez dans l'idée de développer des logiciels utilisant les technologies de Mozilla ou du Web ouvert, vous pourrez trouver des gens pour vous guider et avec qui en discuter dans ce groupe de travail. Ce groupe rassemble aussi les gens qui s'occupent de créer et maintenir les outils et les sites de MozFr. Il y a certes besoin de programmeurs dans ce groupe, mais aussi, par exemple, de designers et de graphistes.</p>
         <dl>
             <dt>Activités</dt>
-            <dd>Développement et maintenance des sites web et outils de MozFr, mais aussi d'<i>add-ons</i>, d'applications Mozilla, d'<i>Open Web Apps</i>, etc.</dd>
+            <dd>Développement et maintenance des sites web et outils de MozFr, mais aussi d'<i lang="en">add-ons</i>, d'applications Mozilla, d'<i>Open Web Apps</i>, etc.</dd>
             <dt>Compétences souhaitées</dt>
             <dd>Développement web (html/css/javasript, php/python/node), design web et graphisme, administration système, mentors pour débutants sur un projet ou un langage.</dd>
             <dt>Référent</dt>
@@ -115,10 +99,10 @@ title: Participer
         </dl>
     </div>
     <h2 id="Suggestions_de_contributions">Suggestions de contributions</h2>
-    <p>Vous trouverez sur le Wiki des <a href="https://wiki.mozfr.org/Id%C3%A9es_de_contributions" title="Idées de contributions">idées de contribution</a> ainsi que des personnes qui peuvent vous aider à mettre le pied à l'étrier et répondre à vos questions. Cette liste n'est pas exhaustive mais peut vous aider à trouver par où commencer.</p>
+    <p>Vous trouverez sur le Wiki des <a href="https://github.com/mozfr/besogne/wiki/Id%C3%A9es-de-contribution" title="Idées de contributions – wiki MozFr">idées de contribution</a> ainsi que des personnes qui peuvent vous aider à mettre le pied à l'étrier et répondre à vos questions. Cette liste n'est pas exhaustive mais peut vous aider à trouver par où commencer.</p>
     <p>Vous pouvez aussi jeter un œil à la <a href="https://www.mozilla.org/fr/contribute/">page <i>Contribuez à Mozilla&#160;!</i></a> sur le site officiel.</p>
     <h2 id="Projets_de_Mozilla">Projets de Mozilla</h2>
-    <p>Vous trouverez une <a href="https://wiki.mozfr.org/Projets_de_Mozilla_et_apparent%C3%A9s" title="Projets de Mozilla et apparentés">liste de projets libres et <i>open source</i> de Mozilla</a>, soutenus par Mozilla ou utilisant des technologies de Mozilla. Cette liste n'est, encore une fois, pas exhaustive.</p>
+    <p>Vous trouverez une <a href="https://github.com/mozfr/besogne/wiki/Projets-de-Mozilla-et-apparent%C3%A9s" title="Projets de Mozilla et apparentés – wiki MozFr">liste de projets libres et <i lang="en">open source</i> de Mozilla</a>, soutenus par Mozilla ou utilisant des technologies de Mozilla. Cette liste n'est, encore une fois, pas exhaustive.</p>
     <p>Vous pourrez également trouver une <a href="https://www.mozilla.org/fr/firefox/products/">liste de projets</a> et <a href="https://www.mozilla.org/projects/mozilla-based/">une un peu plus complète en anglais</a>.</p>
 </section>
 


### PR DESCRIPTION
Mise à jour des liens vers le wiki et du référent communication, ajout Facebook MozFr, suppression section Firefox OS, ajout lang="en" pour les termes en anglais.