### PR TITLE
MozFR => Mozilla fr & notreinternet => Mozilla et la vie publique

### DIFF
--- a/source/_layouts/default.html.twig
+++ b/source/_layouts/default.html.twig
@@ -38,7 +38,7 @@
                 <a href="https://www.mozilla.org/fr/firefox/new/?from=mozfr"><img src="/img/FFx-Australis_banner_300x250.png" alt="Engagé pour le Web ouvert, téléchargez Firefox"></a>
             </p>
             <div class="section">
-                <h2>MozFR ailleurs</h2>
+                <h2>Mozilla fr ailleurs</h2>
                 <ul id="sns">
                     <li id="facebooklogo"><a href="https://facebook.com/frmozilla/">Facebook</a></li>
                     <li id="twitterlogo"><a href="https://twitter.com/mozilla_fr/">Twitter</a></li>
@@ -93,10 +93,10 @@
                 <h2>Nos blogs thématiques</h2>
                 <ul id="activities">
                     <li id="mozfr">
-                        <a href="https://blog.mozfr.org/" title="Blog généraliste de la communauté francophone">Blog de MozFr</a>
+                        <a href="https://blog.mozfr.org/" title="Blog généraliste de la communauté francophone">Blog de Mozilla fr</a>
                     </li>
                     <li id="notreinternet">
-                        <a href="https://notreinternet.mozfr.org/" title="Blog sur les lois et Internet">Notre Internet</a>
+                        <a href="https://notreinternet.mozfr.org/" title="Blog sur les lois et Internet">Mozilla et la vie publique</a>
                     </li>
                     <li id="bidouilleux">
                         <a href="https://tech.mozfr.org/" title="Blog technique de la communauté Mozilla francophone">Bidouilleux d'Web</a>


### PR DESCRIPTION
On avait convenu que le « MozFR » servirait dans la communication purement interne, sinon, si on avait besoin d'abréger, ce serait « Mozilla fr » et j'en ai profité pour mettre le nom du blog notreinternet : Mozilla et la vie publique.