### PR TITLE
Mise à jour du pied de page

### DIFF
--- a/source/_layouts/default.html.twig
+++ b/source/_layouts/default.html.twig
@@ -82,10 +82,8 @@
                     <ul>
                         <li><a href="https://www.mozilla.org/fr/firefox/new">Firefox</a></li>
                         <li><a href="https://www.mozilla.org/fr/firefox/channel/desktop/?from=mozfr">Préversions de Firefox</a></li>
-                        <li><a href="https://play.google.com/store/apps/details?id=org.mozilla.fenix&amp;gl=FR">Firefox Preview pour Android</a></li>
+                        <li><a href="https://play.google.com/store/apps/details?id=org.mozilla.fenix&amp;gl=FR">Firefox pour Android</a></li>
                         <li><a href="https://www.thunderbird.net/fr/">Thunderbird</a></li>
-                        <li><a href="https://lockwise.firefox.com/">Firefox Lockwise</a></li>
-                        <li><a href="https://send.firefox.com/">Firefox Send</a></li>
                         <li><a href="https://monitor.firefox.com/">Firefox Monitor</a></li>
                     </ul>
                     </div>
@@ -109,11 +107,11 @@
                 </p>
 
                 <p>
-                    Le <a href="https://github.com/mozfr/www">code source</a> du site est sous licence <a href="https://www.mozilla.org/en-US/MPL/2.0/">Mozilla Public License Version 2.0</a>.
+                    Le <a href="https://github.com/mozfr/www">code source</a> du site est disponible sous licence <a href="https://www.mozilla.org/en-US/MPL/2.0/">Mozilla Public License Version 2.0</a>.
                 </p>
 
                 <p>
-                    Ce site est maintenu par des bénévoles et n'est pas un site officiel de la
+                    Ce site est maintenu par des bénévoles et n’est pas un site officiel de la
                     <a href="https://www.mozilla.org/fr/">fondation Mozilla</a>.
                 </p>
 


### PR DESCRIPTION
Pied de page :
* suppression de « Preview » pour Firefox pour Android
* suppression des items Firefox Lockwise (inclus dans Firefox) et Firefox Send (abandonné)
* ajout de « disponible » pour la seconde phrase de licence
* remplacement d'une apostrophe droite par une typographique