### PR TITLE
mise à jour des informations

### DIFF
--- a/source/participer.html
+++ b/source/participer.html
@@ -18,8 +18,8 @@ title: Participer
         <div>
             <ul>
                 <li>Vous pouvez commencer par vous inscrire à la <a href="/liste">liste de diffusion</a> de la communauté francophone pour participer aux projets et partager des idées.</li>
-                <li>Des <a href="https://github.com/mozfr/besogne/wiki/IRC" title="IRC" class="mw-redirect">canaux IRC francophones</a> vous permettent de discuter en ligne avec les membres de la communauté qui y sont connectés en même temps que vous depuis divers endroits dans le monde. Certains salons sont thématiques (développement, aide…), mais vous pouvez aussi discuter de tout et de rien sur #frenchmoz.</li>
-                <li>Nous sommes présents sur <a href="https://twitter.com/mozilla_fr">Twitter</a> , <a href="https://www.facebook.com/frmozilla/">Facebook</a> et <a href="https://www.youtube.com/channel/UCyieisb28vyXaltYRFsHDaQ">Youtube</a>.</li>
+                <li>Des <a href="https://github.com/mozfr/besogne/wiki/Matrix" title="Matrix – mozfr wiki" class="mw-redirect">salons Matrix francophones</a> vous permettent de discuter en ligne avec les membres de la communauté qui y sont connectés en même temps que vous depuis divers endroits dans le monde. Certains salons sont thématiques (développement, aide…), mais vous pouvez aussi discuter de tout et de rien sur #mozfr.</li>
+                <li>Nous sommes présents sur <a href="https://twitter.com/mozilla_fr">Twitter</a> et <a href="https://mamot.fr/@Mozilla">Mastodon</a>.</li>
             </ul>
         </div>
     </details>
@@ -48,23 +48,23 @@ title: Participer
                     <dt>Compétences souhaitées</dt>
                     <dd>Bonne compréhension de l’anglais et bonne maîtrise du français.</dd>
                     <dt>Référent</dt>
-                    <dd><a href="https://twitter.com/Goofy_fr" title="Goofy">Goofy</a></dd>
+                    <dd><a href="https://framapiaf.org/@goofy" title="Goofy (@goofy@framapiaf.org) – Framapiaf">Goofy</a></dd>
                 </dl>
-                <p><a href="https://github.com/mozfr/besogne/wiki/Traduction" title="Contribuer aux traductions">Comment contribuer, tout savoir ou presque</a></p>
+                <p><a href="https://github.com/mozfr/besogne/wiki/Traduction" title="Contribuer aux traductions – mozfr wiki">Comment contribuer, tout savoir ou presque</a></p>
             </div>
 
             <div id="assistance_aux_utilisateurs">
-                <h3><a href="#assistance_aux_utilisateurs">Assistance aux utilisateurs</a></h3>
-                <p>Il existe plusieurs moyens d’aider les utilisateurs suivant le temps que vous êtes prêts à y consacrer, que ce soit quelques minutes à l’occasion ou plus régulièrement.</p>
-                <p>Si vous maîtrisez les logiciels de Mozilla ou êtes prêt à prendre le temps de combler vos lacunes, vous pouvez aider d’autres utilisateurs. Bonus&#160;: la reconnaissance des utilisateurs que vous aiderez.</p>
+                <h3><a href="#assistance_aux_utilisateurs">Assistance aux utilisateurs et utilisatrices</a></h3>
+                <p>Il existe plusieurs moyens d’aider les utilisateurs et les utilisatrices selon le temps que vous avez à y consacrer, que ce soit quelques minutes à l’occasion ou plus régulièrement.</p>
+                <p>Si vous maîtrisez les logiciels de Mozilla ou vouliez prendre le temps de combler vos lacunes, vous pouvez aider d’autres utilisateurs ou utilisatrices. Bonus&#160;: la reconnaissance des personnes que vous aiderez.</p>
                 <dl>
                     <dt>Activités</dt>
-                    <dd>Aide aux utilisateurs de logiciels, sites et services de Mozilla ou basés sur ses technologies.</dd>
+                    <dd>Aide aux utilisateurs et utilisatrices de logiciels, sites et services de Mozilla ou basés sur ses technologies.</dd>
                     <dt>Compétences souhaitées</dt>
                     <dd>Bonne utilisation des applications Mozilla, pédagogie, rédaction correcte.</dd>
                     <dt>Référent</dt>
-                    <dd>&#160;?</dd>
-                    <dt>Sites d’assistance aux utilisateurs</dt>
+                    <dd><a href="https://twitter.com/hellosct1" title="Christophe Villeneuve (@hellosct1) – Twitter">Christophe Villeneuve</dd>
+                    <dt>Sites d’assistance aux utilisateurs et utilisatrices</dt>
                     <dd><a href="https://support.mozilla.org/fr/kb/benevoles-recherches">SuMo</a></dd>
                     <dd><a href="https://forums.mozfr.org/">Forum Geckozone</a></dd>
                 </dl>
@@ -75,14 +75,14 @@ title: Participer
                 <p>Vous êtes capable d’écrire sur ces sujets, de donner des conférences, voire des cours à des étudiants&#160;? Le groupe d’éducation et de promotion technique n’attendait que vous&#160;!</p>
                 <dl>
                     <dt>Activités</dt>
-                    <dd>Familiariser les développeurs et le reste du monde aux technologies du Web ouvert à travers l’écriture d’articles et l’organisation d’évènements.</dd>
+                    <dd>Familiariser les développeurs et développeuses et le reste du monde aux technologies du Web ouvert à travers l’écriture d’articles et l’organisation d’évènements.</dd>
                     <dt>Compétences souhaitées</dt>
                     <dd>Connaissances sur les technologies web, pédagogie, rédaction.</dd>
                     <dt>Référent</dt>
-                    <dd><a href="https://twitter.com/JeremiePat" title="Jeremie">Jérémie</a></dd>
+                    <dd><a href="https://twitter.com/JeremiePat" title="Jérémie Patonnier (@JeremiePat) – Twitter">Jérémie</a></dd>
                     <dt>Sites de ce groupe</dt>
                     <dd><a href="https://tech.mozfr.org/">Blog Bidouilleux d’Web</a></dd>
-                    <dd><a href="https://github.com/mozfr/besogne/wiki/Techno" title="Techno">Page du groupe sur le Wiki</a></dd>
+                    <dd><a href="https://github.com/mozfr/besogne/wiki/Techno" title="Techno – mozfr wiki">Page du groupe sur le wiki</a></dd>
                 </dl>
             </div>
             <div id="communication">
@@ -95,26 +95,26 @@ title: Participer
                     <dt>Compétences souhaitées</dt>
                     <dd>Rédaction, enthousiasme, organisation.</dd>
                     <dt>Référent</dt>
-                    <dd><a href="https://mozillians.org/u/mozinet" title="Utilisateur:Mozinet">Mozinet</a></dd>
+                    <dd><a href="https://people.mozilla.org/p/Mozinet" title="Pierre Mozinet (@Mozinet) – Mozilla People Directory">Mozinet</a></dd>
                     <dt>Sites de ce groupe</dt>
                     <dd><a href="https://blog.mozfr.org/">Blog</a></dd>
-                    <dd><a href="https://github.com/mozfr/besogne/wiki/Communication" title="Communication – wiki Mozfr">Page du groupe sur le Wiki</a></dd>
+                    <dd><a href="https://github.com/mozfr/besogne/wiki/Communication" title="Communication – wiki Mozfr">Page du groupe sur le wiki</a></dd>
                 </dl>
             </div>
             <div id="developpement">
                 <h3><a href="#developpement">Développement</a></h3>
                 <p>Ici, on développe des outils pour MozFr, mais on s’entraide aussi pour maîtriser les technologies web et la programmation dans divers langages, du JavaScript au C++&#160;!</p>
-                <p>Si vous avez dans l’idée de développer des logiciels utilisant les technologies de Mozilla ou du Web ouvert, vous pourrez trouver des gens pour vous guider et avec qui en discuter dans ce groupe de travail. Ce groupe rassemble aussi les gens qui s’occupent de créer et maintenir les outils et les sites de MozFr. Il y a certes besoin de programmeurs dans ce groupe, mais aussi, par exemple, de designers et de graphistes.</p>
+                <p>Si vous avez dans l’idée de développer des logiciels utilisant les technologies de Mozilla ou du Web ouvert, vous pourrez trouver des gens pour vous guider et avec qui en discuter dans ce groupe de travail. Ce groupe rassemble aussi les gens qui s’occupent de créer et maintenir les outils et les sites de MozFr. Il y a certes besoin de programmeurs et programmeuses dans ce groupe, mais aussi, par exemple, de designers et de graphistes.</p>
                 <dl>
                     <dt>Activités</dt>
-                    <dd>Développement et maintenance des sites web et outils de MozFr, mais aussi d’<i lang="en">add-ons</i>, d’applications Mozilla, d’<i>Open Web Apps</i>, etc.</dd>
+                    <dd>Développement et maintenance des sites web et outils de MozFr, mais aussi de modules complémentaires, d’applications Mozilla, d’<i lang="en">Open Web Apps</i>, etc.</dd>
                     <dt>Compétences souhaitées</dt>
-                    <dd>Développement web (html/css/javasript, php/python/node), design web et graphisme, administration système, mentors pour débutants sur un projet ou un langage.</dd>
+                    <dd>Développement web (html/css/javasript, php/python/node), design web et graphisme, administration système, mentors pour débutant·e·s sur un projet ou un langage.</dd>
                     <dt>Référent</dt>
-                    <dd><a href="https://twitter.com/pascalchevrel" title="Pascalc">Pascalc</a></dd>
+                    <dd><a href="https://twitter.com/pascalchevrel" title="Pascal Chevrel (@pascalchevrel) – Twitter">Pascalc</a></dd>
                     <dt>Sites de ce groupe</dt>
-                    <dd><a href="https://github.com/mozfr">MozFr sur github</a></dd>
-                    <dd><a href="https://github.com/mozfr/besogne/wiki/Devops" title="Devops">Page du groupe sur le Wiki</a></dd>
+                    <dd><a href="https://github.com/mozfr">MozFr sur GitHub</a></dd>
+                    <dd><a href="https://github.com/mozfr/besogne/wiki/Devops" title="Devops – mozfr wiki">Page du groupe sur le wiki</a></dd>
                 </dl>
             </div>
         </div>
@@ -124,8 +124,8 @@ title: Participer
             <p>Vous trouverez ici des <a href="https://github.com/mozfr/besogne/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20-label%3A%22admin%20sys%22" title="Idées de contributions">idées de contribution</a>. N’hésitez pas à contacter les personnes sur IRC qui pourront vous aider à mettre le pied à l’étrier et répondre à vos questions. Cette liste n’est pas exhaustive mais peut vous aider à trouver par où commencer.</p>
             <p>Vous pouvez aussi jeter un œil à la <a href="https://www.mozilla.org/fr/contribute/">page <i>Contribuez à Mozilla&#160;!</i></a> sur le site officiel.</p>
             <h2 id="Projets_de_Mozilla">Projets de Mozilla</h2>
-            <p>Vous trouverez une <a href="https://github.com/mozfr/besogne/wiki/Projets-de-Mozilla-et-apparent%C3%A9s" title="Projets de Mozilla et apparentés – wiki MozFr">liste de projets libres et <i lang="en">open source</i> de Mozilla</a>, soutenus par Mozilla ou utilisant des technologies de Mozilla. Cette liste n’est, encore une fois, pas exhaustive.</p>
-            <p>Vous pourrez également trouver une <a href="https://www.mozilla.org/fr/firefox/products/">liste de projets</a> et <a href="https://www.mozilla.org/projects/mozilla-based/">une un peu plus complète en anglais</a>.</p>
+            <p>Vous trouverez une <a href="https://github.com/mozfr/besogne/wiki/Projets-de-Mozilla-et-apparent%C3%A9s" title="Projets de Mozilla et apparentés – mozfr wiki">liste de projets libres et <i lang="en">open source</i> de Mozilla</a>, soutenus par Mozilla ou utilisant des technologies de Mozilla. Cette liste n’est, encore une fois, pas exhaustive.</p>
+            <p>Vous pourrez également trouver une <a href="https://www.mozilla.org/fr/firefox/products/">liste de projets</a> et <a href="https://developer.mozilla.org/en-US/docs/Archive/List_of_Mozilla-Based_Applications">une un peu plus complète en anglais</a>.</p>
         </div>
     </details>
 </section>


### PR DESCRIPTION
IRC ⇾ Matrix
Réseaux sociaux : suppression de Facebook et YouTube (où nous n'avons pas de réelle communication) et ajout de Mastodon
Mise à jour de liens
Langage inclusif
Ajout de Christophe Villeneuve comme référent de l'assistance (plus gros contributeur)