### PR TITLE
Corrige le débordement du pied de page

### DIFF
--- a/source/css/style.css
+++ b/source/css/style.css
@@ -234,6 +234,10 @@ footer section#links ul {
 footer section#credits {
     text-align: center;
     font-size: small;
+
+    & p {
+      margin-block-end: 0;
+    }
 }
 
 


### PR DESCRIPTION
Le pied de page débordait de son conteneur dû à la valeur par défaut de la marge (`margin-block`) des paragraphes. 

**Avant**
![image](https://github.com/user-attachments/assets/3a675a1d-0441-49ca-816e-3c288127fbee)

**Après**
![image](https://github.com/user-attachments/assets/ab3794e9-675f-441d-ad74-199dd4189266)
