### PR TITLE
Gestion des menus avec Cecil site.menus

### DIFF
--- a/source/cecil.yml
+++ b/source/cecil.yml
@@ -18,3 +18,79 @@ pages:
       published: false
     xsl/rss:
       published: false
+
+menus:
+  # Navbar menu
+  main:
+    # We disable the index link sine we already use the navbar logo for that.
+    - id: index
+      enabled: false
+    - id: news
+      name: "Nouvelles"
+      url: "https://blog.mozfr.org"
+      foobar: "foobar"
+    - id: forum
+      name: "Forums et assistance"
+      url: "https://forums.mozfr.org"
+    - id: contribute
+      name: "Participer"
+      url: "/participer/"
+    - id: about
+      name: "À propos"
+      url: "/manifesto/"
+  communication:
+    - id: main-blog
+      name: "Blog principal"
+      url: "https://blog.mozfr.org"
+    - id: technical-blog
+      name: "Blog technique"
+      url: "https://tech.mozfr.org"
+    - id: our-internet
+      name: "Mozilla et la vie publique"
+      url: "https://notreinternet.mozfr.org"
+    - id: planet
+      name: "Planète Mozilla francophone"
+      url: "https://planete.mozfr.org"
+    - id: twitter
+      name: "Suivez-nous sur Twitter"
+      url: "https://twitter.com/Mozilla_fr"
+    - id: mastodon
+      name: "Suivez-nous sur Mastodon"
+      url: "https://mamot.fr/@Mozilla"
+  softwares:
+    - id: firefox
+      name: "Firefox"
+      url: "https://www.mozilla.org/fr/firefox/new?from=mozfr"
+    - id: firefox-channels
+      name: "Préversions de Firefox"
+      url: "https://www.mozilla.org/fr/firefox/channel/desktop/?from=mozfr"
+    - id: firefox-android
+      name: "Firefox pour Android"
+      url: "https://play.google.com/store/apps/details?id=org.mozilla.fenix&amp;gl=FR"
+    - id: firefox-monitor
+      name: "Firefox Monitor"
+      url: "https://monitor.firefox.com/"
+    - id: thunderbird
+      name: "Thunderbird"
+      url: "https://www.thunderbird.net/fr/"
+    - id: thunderbird-android
+      name: "Thunderbird pour Android"
+      url: "https://play.google.com/store/apps/details?id=net.thunderbird.android&amp;gl=FR"
+  about:
+    - id: manifesto
+      name: "Le manifeste de Mozilla"
+      url: "/manifesto/"
+    - id: contribute
+      name: "Participer"
+      url: "/participer/"
+    - id: translate
+      name: "Traduire"
+      url: "https://github.com/mozfr/besogne/wiki/Traduction"
+    - id: forum
+      name: "Forums et assistance"
+      url: "https://forums.mozfr.org"
+    - id: wiki
+      name: "Wiki d'équipe"
+      url: "https://github.com/mozfr/besogne/wiki/"
+
+debug: true

--- a/source/layouts/partials/footer.html.twig
+++ b/source/layouts/partials/footer.html.twig
@@ -4,37 +4,26 @@
 
 <div class="inner-footer">
     <section id="links">
-    <a href="/" title="Mozilla francophone" class="mozfrtext">moz<span>fr</span></a>
+    <a href="/" title="Mozilla francophone" class="mozfrtext">
+      moz<span>fr</span>
+    </a>
         <div>
         <h3>Communication</h3>
-        <ul>
-            <li><a href="https://blog.mozfr.org">Blog principal</a></li>
-            <li><a href="https://tech.mozfr.org">Blog technique</a></li>
-            <li><a href="https://notreinternet.mozfr.org">Mozilla et la vie publique</a></li>
-            <li><a href="https://planete.mozfr.org">Planète Mozilla francophone</a></li>
-            <li><a href="https://twitter.com/Mozilla_fr">Suivez-nous sur Twitter</a></li>
-            <li><a rel="me" href="https://mamot.fr/@Mozilla">Suivez-nous sur Mastodon</a></li>
-        </ul>
+        {% include 'partials/menu.html.twig'
+          with { 'menu': site.menus.communication }
+        %}
         </div>
         <div>
         <h3>Logiciels</h3>
-        <ul>
-            <li><a href="https://www.mozilla.org/fr/firefox/new">Firefox</a></li>
-            <li><a href="https://www.mozilla.org/fr/firefox/channel/desktop/?from=mozfr">Préversions de Firefox</a></li>
-            <li><a href="https://play.google.com/store/apps/details?id=org.mozilla.fenix&amp;gl=FR">Firefox pour Android</a></li>
-            <li><a href="https://www.thunderbird.net/fr/">Thunderbird</a></li>
-            <li><a href="https://monitor.firefox.com/">Firefox Monitor</a></li>
-        </ul>
+        {% include 'partials/menu.html.twig'
+          with { 'menu': site.menus.softwares }
+        %}
         </div>
         <div>
         <h3>À propos</h3>
-        <ul>
-            <li><a href="/manifesto">Le manifeste de Mozilla</a></li>
-            <li><a href="/participer">Participer</a></li>
-            <li><a href="https://github.com/mozfr/besogne/wiki/Traduction">Traduire</a></li>
-            <li><a href="https://forums.mozfr.org/">Forums et assistance</a></li>
-            <li><a href="https://github.com/mozfr/besogne/wiki">Wiki d’équipe</a></li>
-        </ul>
+        {% include 'partials/menu.html.twig'
+          with { 'menu': site.menus.about }
+        %}
         </div>
     </section>
 </div>

--- a/source/layouts/partials/menu.html.twig
+++ b/source/layouts/partials/menu.html.twig
@@ -1,0 +1,13 @@
+{# This Source Code Form is subject to the terms of the Mozilla Public
+ # License, v. 2.0. If a copy of the MPL was not distributed with this
+ # file, You can obtain one at https://mozilla.org/MPL/2.0/. #}
+
+<ul>
+    {% for item in menu %}
+    <li>
+      <a href="{{ url(item.url) }}">
+        {{ item.name }}
+      </a>
+    </li>
+    {% endfor %}
+</ul>

--- a/source/layouts/partials/navbar.html.twig
+++ b/source/layouts/partials/navbar.html.twig
@@ -4,11 +4,10 @@
 
 <a href="/" title="Mozilla francophone" class="mozfrtext">moz<span>fr</span></a>
 <nav id="nav-main" role="navigation">
-    <ul>
-        <li><a href="//blog.mozfr.org">Nouvelles</a></li>
-        <li><a href="//forums.mozfr.org">Forums et assistance</a></li>
-        <li><a href="/participer">Participer</a></li>
-        <li><a href="/manifesto">À propos</a></li>
-    </ul>
+  {% include 'partials/menu.html.twig' with { 'menu': site.menus.main } %}
 </nav>
-<a href="https://www.mozilla.org/fr/firefox/download/thanks/?source=mozfr" class="getfirefox">Télécharger Firefox</a>
+<a href="https://www.mozilla.org/fr/firefox/download/thanks/?source=mozfr"
+   class="getfirefox">
+  Télécharger Firefox
+</a>
+


### PR DESCRIPTION
Cette patch remplace les liens insérés directement dans le code html par des menus accessible via site.menus. Ainsi, il est plus facile de les mettre à jour et de les réutiliser dans différentes sections du site. Un *partial* est aussi disponible pour rapidement créer le markup des menus dans les *layouts*. 